### PR TITLE
어르신용 달력  api연동 및 라우팅

### DIFF
--- a/lib/api_service.dart
+++ b/lib/api_service.dart
@@ -55,8 +55,8 @@ class ApiService {
 
   // @GET schedules/schedule 전체 일정 조회
   // 유저의 전체 일정 조회
-  Future<Map<String, dynamic>> fetchScheduleData(int userId) async {
-    final String url = 'http://172.23.241.36:8000/api/v1/schedule?user_id=$userId&skip=0&limit=10';
+  Future<List<dynamic>> fetchScheduleData(int userId) async {
+    final String url = 'http://172.23.241.36:8000/api/v1/schedule?user_id=$userId';
 
     try {
       final response = await http.get(
@@ -67,19 +67,17 @@ class ApiService {
       );
 
       if (response.statusCode == 200) {
-        // 응답 데이터를 디코딩하여 반환
-        final Map<String, dynamic> data = jsonDecode(utf8.decode(response.bodyBytes));
+        final List<dynamic> data = jsonDecode(utf8.decode(response.bodyBytes)) as List<dynamic>;
         return data;
       } else {
-        return {'error': '서버와의 통신 오류가 있습니다. 상태 코드: ${response.statusCode}'};
+        return []; // 서버 오류 시 빈 리스트 반환
       }
     } catch (e) {
-      return {
-        'error': '서버와의 통신 오류가 있습니다.',
-        'exception': e.toString(),
-      };
+      print('Error fetching schedules: $e');
+      return [];
     }
   }
+
 
 
   // @GET schedules/schedules/{schedule_id}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,7 +5,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'screen/map_list/tmap.dart';
 import 'screen/chat_screen.dart';
-import 'screen/summary/message_summary_normal.dart';
+import 'screen/summary/start_summary_screen.dart';
 import 'screen/summary/summary_result_normal.dart';
 import 'screen/summary/summary_result_to_calendar.dart';
 import 'screen/loading_screen.dart';

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -80,10 +80,15 @@ final GoRouter router = GoRouter(
     GoRoute(
       path: '/daily-schedule',
       builder: (context, state) {
-        final selectedDate = state.extra as DateTime;
-        return ScheduleDailyScreen(selectedDate: selectedDate);
+        final Map<String, Object> data = state.extra as Map<String, Object>;
+        final DateTime selectedDate = data['selectedDate'] as DateTime;
+
+        return ScheduleDailyScreen(
+          selectedDate: selectedDate,
+        );
       },
     ),
+
     GoRoute(
       path: '/smsListScreen',
       builder: (context, state) => SmsListScreen(),

--- a/lib/screen/calendar/today_calendar.dart
+++ b/lib/screen/calendar/today_calendar.dart
@@ -75,25 +75,6 @@ class _ScheduleDailyScreenState extends State<ScheduleDailyScreen> {
     double selectedBoxHeight = 120;
 
     return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        middle: const Text(
-          '일정',
-          style: TextStyle(
-            fontSize: 24,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-        trailing: CupertinoButton(
-          padding: EdgeInsets.zero,
-          onPressed: () {},
-          child: const Icon(
-            CupertinoIcons.person_crop_circle,
-            color: CupertinoColors.black,
-          ),
-        ),
-        backgroundColor: const Color(0xFFFFC436),
-        border: null,
-      ),
       child: Stack(
         children: [
           SafeArea(
@@ -249,7 +230,6 @@ class _ScheduleDailyScreenState extends State<ScheduleDailyScreen> {
   }
 
   Widget _buildScheduleList(List<dynamic> scheduleList) {
-    // 선택된 날짜에 해당하는 일정만 필터링
     final filteredSchedules = scheduleList.where((schedule) {
       final scheduleDate = DateTime.parse(schedule['schedule_start_time']).toLocal();
       return scheduleDate.year == _selectedYear &&
@@ -257,7 +237,6 @@ class _ScheduleDailyScreenState extends State<ScheduleDailyScreen> {
           scheduleDate.day == _selectedDay;
     }).toList();
 
-    // 필터링된 일정 목록을 화면에 표시
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0),
       child: ListView.builder(
@@ -295,7 +274,7 @@ class _ScheduleDailyScreenState extends State<ScheduleDailyScreen> {
             width: width,
             height: 16,
             decoration: BoxDecoration(
-              color: isSelected ? const Color(0xFF8B4513) : (hasEvent ? Colors.lightGreenAccent.withOpacity(0.9) : CupertinoColors.systemGrey),
+              color: isSelected ? const Color(0xFF8B4513) : (hasEvent ? Colors.lightGreenAccent : CupertinoColors.systemGrey),
               borderRadius: const BorderRadius.vertical(top: Radius.circular(8)),
             ),
           ),
@@ -313,6 +292,10 @@ class _ScheduleDailyScreenState extends State<ScheduleDailyScreen> {
                     offset: const Offset(0, 2),
                   ),
                 ],
+                border: Border.all(
+                  color: hasEvent ? Colors.lightGreenAccent : Colors.transparent,
+                  width: 2.0,
+                ),
               ),
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
1. today_calendar, monthly_calendar.dart의 일정을 전체일정조회 api를 이용해 db에서 호출함
2. 네비게이션바 제거
3. 아이콘 노란색그라데이션에 검은아이콘으로 통일시킴